### PR TITLE
Support existing ALB instead of creating a new one

### DIFF
--- a/terraform/ecs/alb.tf
+++ b/terraform/ecs/alb.tf
@@ -32,12 +32,12 @@ resource "aws_alb_target_group" "shraga_alb_tg" {
 
 resource "aws_alb_listener" "http" {
   count             = local.should_create_alb ? 1 : 0
-  load_balancer_arn = aws_alb.shraga_alb.id
+  load_balancer_arn = aws_alb[0].shraga_alb.id
   port              = 80
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = aws_alb_target_group.shraga_alb_tg.id
+    target_group_arn = aws_alb_target_group[0].shraga_alb_tg.id
     type             = "forward"
   }
 }
@@ -50,13 +50,13 @@ data "aws_acm_certificate" "cert" {
 
 resource "aws_alb_listener" "https" {
   count             = local.should_create_alb ? 1 : 0
-  load_balancer_arn = aws_alb.shraga_alb.id
+  load_balancer_arn = aws_alb[0].shraga_alb.id
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
   certificate_arn   = data.aws_acm_certificate.cert.arn
   default_action {
-    target_group_arn = aws_alb_target_group.shraga_alb_tg.id
+    target_group_arn = aws_alb_target_group[0].shraga_alb_tg.id
     type             = "forward"
   }
 }

--- a/terraform/ecs/alb.tf
+++ b/terraform/ecs/alb.tf
@@ -1,4 +1,9 @@
+locals {
+  should_create_alb = var.alb_tg_arn == null && (var.alb_subnets_ids != null && var.alb_cert_domain != null) ? true : false
+}
+
 resource "aws_alb" "shraga_alb" {
+  count           = local.should_create_alb ? 1 : 0
   name            = "shraga-load-balancer"
   internal        = var.alb_public == true ? false : true
   subnets         = var.alb_subnets_ids
@@ -7,6 +12,7 @@ resource "aws_alb" "shraga_alb" {
 }
 
 resource "aws_alb_target_group" "shraga_alb_tg" {
+  count       = local.should_create_alb ? 1 : 0
   name        = "shraga-alb-target-group"
   port        = 8000
   protocol    = "HTTP"
@@ -25,6 +31,7 @@ resource "aws_alb_target_group" "shraga_alb_tg" {
 }
 
 resource "aws_alb_listener" "http" {
+  count             = local.should_create_alb ? 1 : 0
   load_balancer_arn = aws_alb.shraga_alb.id
   port              = 80
   protocol          = "HTTP"
@@ -36,11 +43,13 @@ resource "aws_alb_listener" "http" {
 }
 
 data "aws_acm_certificate" "cert" {
+  count    = local.should_create_alb ? 1 : 0
   domain   = var.alb_cert_domain
   statuses = ["ISSUED"]
 }
 
 resource "aws_alb_listener" "https" {
+  count             = local.should_create_alb ? 1 : 0
   load_balancer_arn = aws_alb.shraga_alb.id
   port              = 443
   protocol          = "HTTPS"

--- a/terraform/ecs/alb.tf
+++ b/terraform/ecs/alb.tf
@@ -54,7 +54,7 @@ resource "aws_alb_listener" "https" {
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = data.aws_acm_certificate.cert.arn
+  certificate_arn   = data.aws_acm_certificate.cert[0].arn
   default_action {
     target_group_arn = aws_alb_target_group.shraga_alb_tg[0].id
     type             = "forward"

--- a/terraform/ecs/alb.tf
+++ b/terraform/ecs/alb.tf
@@ -32,12 +32,12 @@ resource "aws_alb_target_group" "shraga_alb_tg" {
 
 resource "aws_alb_listener" "http" {
   count             = local.should_create_alb ? 1 : 0
-  load_balancer_arn = aws_alb[0].shraga_alb.id
+  load_balancer_arn = aws_alb.shraga_alb[0].id
   port              = 80
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = aws_alb_target_group[0].shraga_alb_tg.id
+    target_group_arn = aws_alb_target_group.shraga_alb_tg[0].id
     type             = "forward"
   }
 }
@@ -50,13 +50,13 @@ data "aws_acm_certificate" "cert" {
 
 resource "aws_alb_listener" "https" {
   count             = local.should_create_alb ? 1 : 0
-  load_balancer_arn = aws_alb[0].shraga_alb.id
+  load_balancer_arn = aws_alb.shraga_alb[0].id
   port              = 443
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
   certificate_arn   = data.aws_acm_certificate.cert.arn
   default_action {
-    target_group_arn = aws_alb_target_group[0].shraga_alb_tg.id
+    target_group_arn = aws_alb_target_group.shraga_alb_tg[0].id
     type             = "forward"
   }
 }

--- a/terraform/ecs/ecs.tf
+++ b/terraform/ecs/ecs.tf
@@ -117,7 +117,7 @@ resource "aws_ecs_service" "shraga_srv" {
   }
 
   load_balancer {
-    target_group_arn = local.should_create_alb ? aws_alb_target_group.shraga_alb_tg.arn : var.alb_tg_arn
+    target_group_arn = local.should_create_alb ? aws_alb_target_group[0].shraga_alb_tg.arn : var.alb_tg_arn
     container_name   = "shraga-app"
     container_port   = 8000
   }

--- a/terraform/ecs/ecs.tf
+++ b/terraform/ecs/ecs.tf
@@ -117,7 +117,7 @@ resource "aws_ecs_service" "shraga_srv" {
   }
 
   load_balancer {
-    target_group_arn = aws_alb_target_group.shraga_alb_tg.arn
+    target_group_arn = local.should_create_alb ? aws_alb_target_group.shraga_alb_tg.arn : var.alb_tg_arn
     container_name   = "shraga-app"
     container_port   = 8000
   }

--- a/terraform/ecs/ecs.tf
+++ b/terraform/ecs/ecs.tf
@@ -117,7 +117,7 @@ resource "aws_ecs_service" "shraga_srv" {
   }
 
   load_balancer {
-    target_group_arn = local.should_create_alb ? aws_alb_target_group[0].shraga_alb_tg.arn : var.alb_tg_arn
+    target_group_arn = local.should_create_alb ? aws_alb_target_group.shraga_alb_tg[0].arn : var.alb_tg_arn
     container_name   = "shraga-app"
     container_port   = 8000
   }

--- a/terraform/ecs/variables.tf
+++ b/terraform/ecs/variables.tf
@@ -21,17 +21,30 @@ variable "ecs_subnets_ids" {
 variable "alb_subnets_ids" {
   description = "Subnets used for ALB deployment, if `var.alb_public == false` set private subnets"
   type        = list(string)
+  default     = null
 }
 
 variable "alb_cert_domain" {
   description = "Domain used for SSL termination on ALB"
   type        = string
+  default     = null
 }
 
 variable "alb_public" {
   description = "Make ALB publicly available"
   type        = bool
   default     = false
+}
+
+variable "alb_tg_arn" {
+  description = "ARN of the target group"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.alb_tg_arn != null || (var.alb_subnets_ids != null && var.alb_cert_domain != null)
+    error_message = "ALB target group ARN is required when `var.alb_subnets_ids` and `var.alb_cert_domain` are not set"
+  }
 }
 
 variable "app_config" {


### PR DESCRIPTION
@lizozom this is needed for EPR since they'll create their own Load Balancer (ALB) manually instead of letting us create through the Terraform.