### PR TITLE
Reduce logs noise

### DIFF
--- a/shraga_common/app/middlewares.py
+++ b/shraga_common/app/middlewares.py
@@ -17,7 +17,11 @@ async def logging_middleware(request: Request, call_next) -> Response:
 
         response = await call_next(request)
 
-        user_display_name = getattr(request.state, "user_display_name", "anonymous")
+        if request.url.path == "/healthz":
+            return response
+
+        user_display_name = getattr(
+            request.state, "user_display_name", "anonymous")
 
         took = int((time.time() - start_time) * 1000)
         shraga_config = get_config()

--- a/terraform/ecs/alb.tf
+++ b/terraform/ecs/alb.tf
@@ -25,7 +25,7 @@ resource "aws_alb_target_group" "shraga_alb_tg" {
     protocol            = "HTTP"
     matcher             = "200"
     timeout             = "3"
-    path                = "/"
+    path                = "/healthz"
     unhealthy_threshold = "2"
   }
 }


### PR DESCRIPTION
We currently log all healthcheck requests from the ALB. This adds a lot of noise to the logs:

![Screenshot from 2025-04-08 22-17-25](https://github.com/user-attachments/assets/97ccefaf-246e-422f-9f37-7ea0de811196)

This PR changes the healthcheck route from "/" to "/healthz" and exclude it from the logs.